### PR TITLE
Use formfield components instead of input-with-label

### DIFF
--- a/public/views/partials/organisms/login.liquid
+++ b/public/views/partials/organisms/login.liquid
@@ -18,7 +18,7 @@ metadata:
     assign label_params = '{}' | parse_json | hash_merge: content: 'E-mail'
     assign description_params = '{}' | parse_json | hash_merge: content: 'E-mail address of the user'
     assign fieldset_params = '{}' | parse_json | hash_merge: label_params: label_params, input_params: input_params, description_params: description_params
-    theme_render_rc 'components/molecules/input-with-label', params: fieldset_params
+    theme_render_rc 'components/molecules/formfield', params: fieldset_params
   %}
 
   {% liquid
@@ -26,7 +26,7 @@ metadata:
     assign label_params = '{}' | parse_json | hash_merge: content: 'Password'
     assign description_params = '{}' | parse_json | hash_merge: content: 'Password'
     assign fieldset_params = '{}' | parse_json | hash_merge: label_params: label_params, input_params: input_params, description_params: description_params
-    theme_render_rc 'components/molecules/input-with-label', params: fieldset_params
+    theme_render_rc 'components/molecules/formfield', params: fieldset_params
   %}
 
   {% liquid

--- a/public/views/partials/organisms/register.liquid
+++ b/public/views/partials/organisms/register.liquid
@@ -18,7 +18,7 @@ metadata:
     assign label_params = '{}' | parse_json | hash_merge: content: 'E-mail'
     assign description_params = '{}' | parse_json | hash_merge: content: 'E-mail address of the user'
     assign fieldset_params = '{}' | parse_json | hash_merge: label_params: label_params, input_params: input_params, description_params: description_params
-    theme_render_rc 'components/molecules/input-with-label', params: fieldset_params
+    theme_render_rc 'components/molecules/formfield', params: fieldset_params
   %}
 
   {% liquid
@@ -26,7 +26,7 @@ metadata:
     assign label_params = '{}' | parse_json | hash_merge: content: 'Password'
     assign description_params = '{}' | parse_json | hash_merge: content: 'Password'
     assign fieldset_params = '{}' | parse_json | hash_merge: label_params: label_params, input_params: input_params, description_params: description_params
-    theme_render_rc 'components/molecules/input-with-label', params: fieldset_params
+    theme_render_rc 'components/molecules/formfield', params: fieldset_params
   %}
 
   {% liquid
@@ -34,7 +34,7 @@ metadata:
     assign label_params = '{}' | parse_json | hash_merge: content: 'Password confirmation'
     assign description_params = '{}' | parse_json | hash_merge: content: 'Please repeat the password'
     assign fieldset_params = '{}' | parse_json | hash_merge: label_params: label_params, input_params: input_params, description_params: description_params
-    theme_render_rc 'components/molecules/input-with-label', params: fieldset_params
+    theme_render_rc 'components/molecules/formfield', params: fieldset_params
   %}
 
   {% liquid


### PR DESCRIPTION
# Description

`input-with-label` component does not exist, that's why I changed them to `formfield`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
